### PR TITLE
Remove wasteful checks

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -5,6 +5,7 @@
 #include <shared_mutex>
 #include "pipeline_benchmark.cpp"
 #include <BS_thread_pool.hpp>
+#include <semaphore>
 
 static void PM_LockUnlock(benchmark::State& state) {
     PrioSync::priority_mutex<10> m;
@@ -54,35 +55,171 @@ static void STD_S_SLockSUnlock(benchmark::State& state) {
     }
 }
 
-static void PM_pipeline_benchmark(benchmark::State& state) {
+static void PM_pipeline_benchmark_long(benchmark::State& state) {// simulations and longer pipeline stuff
     BS::thread_pool pool(8);
     for (auto _ : state){
-        pool.push_task(_PM_pipeline_benchmark::thread_function, 0, 20, 1, 50);
-        pool.push_task(_PM_pipeline_benchmark::thread_function, 2, 15, 1, 30);
-        pool.push_task(_PM_pipeline_benchmark::thread_function, 2, 20, 1, 20);
-        pool.push_task(_PM_pipeline_benchmark::thread_function, 1, 30, 1, 25);
-        pool.push_task(_PM_pipeline_benchmark::thread_function, 1, 25, 1, 30);
-        pool.push_task(_PM_pipeline_benchmark::thread_function, 3, 10, 1, 10);
-        pool.push_task(_PM_pipeline_benchmark::thread_function, 3, 5,  1, 15);
-        pool.push_task(_PM_pipeline_benchmark::thread_function, 0, 20, 1, 45);
+        pool.push_task(_PM_pipeline_benchmark::thread_function, 0, 20, 10, 50);
+        pool.push_task(_PM_pipeline_benchmark::thread_function, 2, 15, 10, 30);
+        pool.push_task(_PM_pipeline_benchmark::thread_function, 2, 20, 10, 20);
+        pool.push_task(_PM_pipeline_benchmark::thread_function, 1, 30, 10, 25);
+        pool.push_task(_PM_pipeline_benchmark::thread_function, 1, 25, 10, 30);
+        pool.push_task(_PM_pipeline_benchmark::thread_function, 3, 10, 10, 10);
+        pool.push_task(_PM_pipeline_benchmark::thread_function, 3, 5,  10, 15);
+        pool.push_task(_PM_pipeline_benchmark::thread_function, 0, 20, 10, 45);
         pool.wait_for_tasks();
     }
 }
 
-static void STD_pipeline_benchmark(benchmark::State& state) {
+static void STD_pipeline_benchmark_long(benchmark::State& state) {// simulations and longer pipeline stuff
     BS::thread_pool pool(8);
     for (auto _ : state){
-        pool.push_task(_STD_pipeline_benchmark::thread_function, 20, 1, 50);
-        pool.push_task(_STD_pipeline_benchmark::thread_function, 15, 1, 30);
-        pool.push_task(_STD_pipeline_benchmark::thread_function, 20, 1, 20);
-        pool.push_task(_STD_pipeline_benchmark::thread_function, 30, 1, 25);
-        pool.push_task(_STD_pipeline_benchmark::thread_function, 25, 1, 30);
-        pool.push_task(_STD_pipeline_benchmark::thread_function, 10, 1, 10);
-        pool.push_task(_STD_pipeline_benchmark::thread_function, 5,  1, 15);
-        pool.push_task(_STD_pipeline_benchmark::thread_function, 20, 1, 45);
+        pool.push_task(_STD_pipeline_benchmark::thread_function, 20, 10, 50);
+        pool.push_task(_STD_pipeline_benchmark::thread_function, 15, 10, 30);
+        pool.push_task(_STD_pipeline_benchmark::thread_function, 20, 10, 20);
+        pool.push_task(_STD_pipeline_benchmark::thread_function, 30, 10, 25);
+        pool.push_task(_STD_pipeline_benchmark::thread_function, 25, 10, 30);
+        pool.push_task(_STD_pipeline_benchmark::thread_function, 10, 10, 10);
+        pool.push_task(_STD_pipeline_benchmark::thread_function, 5,  10, 15);
+        pool.push_task(_STD_pipeline_benchmark::thread_function, 20, 10, 45);
         pool.wait_for_tasks();
     }
 }
+
+static void PM_pipeline_benchmark_gaming(benchmark::State& state) {
+    BS::thread_pool pool(8);
+    for (auto _ : state){
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 0, 2000, 1000, 5000);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 2, 1500, 1000, 3000);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 2, 2000, 1000, 2000);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 1, 3000, 1000, 2500);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 1, 1000, 1000, 1000);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 3, 500, 1000, 1500);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 3, 500, 1000, 1500);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 0, 2000, 1000, 4500);
+        pool.wait_for_tasks();
+    }
+}
+
+static void STD_pipeline_benchmark_gaming(benchmark::State& state) {
+    BS::thread_pool pool(8);
+    for (auto _ : state){
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 2000, 1000, 5000);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 1500, 1000, 3000);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 2000, 1000, 2000);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 3000, 1000, 2500);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 1000, 1000, 1000);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 500, 1000, 1500);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 500, 1000, 1500);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 2000, 1000, 4500);
+        pool.wait_for_tasks();
+    }
+}
+
+static void PM_pipeline_benchmark_audio(benchmark::State& state) {
+    BS::thread_pool pool(8);
+    for (auto _ : state){
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 0, 200, 100, 500);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 2, 150, 100, 300);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 2, 200, 100, 200);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 1, 300, 100, 250);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 1, 100, 100, 100);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 3, 50, 100, 150);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 3, 50, 100, 150);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_micro, 0, 200, 100, 450);
+        pool.wait_for_tasks();
+    }
+}
+
+static void STD_pipeline_benchmark_audio(benchmark::State& state) {
+    BS::thread_pool pool(8);
+    for (auto _ : state){
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 200, 100, 500);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 150, 100, 300);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 200, 100, 200);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 300, 100, 250);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 100, 100, 100);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 50, 100, 150);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 50, 100, 150);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_micro, 200, 100, 450);
+        pool.wait_for_tasks();
+    }
+}
+
+
+static void PM_pipeline_benchmark_fast(benchmark::State& state) { // at this point I need a better way the majority of time is being wasted on the thread pool push_task
+    BS::thread_pool pool(8);
+    for (auto _ : state){
+        pool.push_task(_PM_pipeline_benchmark::thread_function_nano, 0, 2000, 1000, 5000);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_nano, 2, 1500, 1000, 3000);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_nano, 2, 2000, 1000, 2000);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_nano, 1, 3000, 1000, 2500);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_nano, 1, 1000, 1000, 1000);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_nano, 3, 500, 1000, 1500);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_nano, 3, 500, 1000, 1500);
+        pool.push_task(_PM_pipeline_benchmark::thread_function_nano, 0, 2000, 1000, 4500);
+        pool.wait_for_tasks();
+    }
+}
+
+static void STD_pipeline_benchmark_fast(benchmark::State& state) { // at this point I need a better way the majority of time is being wasted on the thread pool push_task
+    BS::thread_pool pool(8);
+    for (auto _ : state){
+        pool.push_task(_STD_pipeline_benchmark::thread_function_nano, 2000, 1000, 5000);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_nano, 1500, 1000, 3000);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_nano, 2000, 1000, 2000);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_nano, 3000, 1000, 2500);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_nano, 1000, 1000, 1000);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_nano, 500, 1000, 1500);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_nano, 500, 1000, 1500);
+        pool.push_task(_STD_pipeline_benchmark::thread_function_nano, 2000, 1000, 4500);
+        pool.wait_for_tasks();
+    }
+}
+
+/*
+static void PM_pipeline_benchmark_fast(benchmark::State& state) { // 1 iteration only
+    BS::thread_pool pool(8);
+    int iterations = 100;
+    pool.push_task(_PM_pipeline_benchmark::thread_loop, iterations, 0, 2000, 1000, 5000);
+    pool.push_task(_PM_pipeline_benchmark::thread_loop, iterations, 2, 1500, 1000, 3000);
+    pool.push_task(_PM_pipeline_benchmark::thread_loop, iterations, 2, 2000, 1000, 2000);
+    pool.push_task(_PM_pipeline_benchmark::thread_loop, iterations, 1, 3000, 1000, 2500);
+    pool.push_task(_PM_pipeline_benchmark::thread_loop, iterations, 1, 1000, 1000, 1000);
+    pool.push_task(_PM_pipeline_benchmark::thread_loop, iterations, 3, 500, 1000, 1500);
+    pool.push_task(_PM_pipeline_benchmark::thread_loop, iterations, 3, 500, 1000, 1500);
+    pool.push_task(_PM_pipeline_benchmark::thread_loop, iterations, 0, 2000, 1000, 4500);
+    for (auto _ : state){
+        int iterations = 100;
+        for(;iterations != 0; iterations--){
+            _PM_pipeline_benchmark::P.release(8);
+            _PM_pipeline_benchmark::V.acquire();
+            _PM_pipeline_benchmark::V.release(-7);
+        }
+    }
+    pool.wait_for_tasks();
+}
+
+static void STD_pipeline_benchmark_fast(benchmark::State& state) { // 1 iteration only
+    BS::thread_pool pool(8);
+    int iterations = 10000;
+    pool.push_task(_STD_pipeline_benchmark::thread_loop, iterations, 2000, 1000, 5000);
+    pool.push_task(_STD_pipeline_benchmark::thread_loop, iterations, 1500, 1000, 3000);
+    pool.push_task(_STD_pipeline_benchmark::thread_loop, iterations, 2000, 1000, 2000);
+    pool.push_task(_STD_pipeline_benchmark::thread_loop, iterations, 3000, 1000, 2500);
+    pool.push_task(_STD_pipeline_benchmark::thread_loop, iterations, 1000, 1000, 1000);
+    pool.push_task(_STD_pipeline_benchmark::thread_loop, iterations, 500, 1000, 1500);
+    pool.push_task(_STD_pipeline_benchmark::thread_loop, iterations, 500, 1000, 1500);
+    pool.push_task(_STD_pipeline_benchmark::thread_loop, iterations, 2000, 1000, 4500);
+    for (auto _ : state){
+        int iterations = 10000;
+        for(;iterations != 0; iterations--){
+            _STD_pipeline_benchmark::P.release(8);
+            _STD_pipeline_benchmark::V.acquire();
+            _STD_pipeline_benchmark::V.release(-7);
+        }
+    }
+    pool.wait_for_tasks();
+}*/
 
 BENCHMARK(PM_LockUnlock);
 BENCHMARK(STD_LockUnlock);
@@ -93,7 +230,16 @@ BENCHMARK(STD_S_LockUnlock);
 BENCHMARK(PM_S_SLockSUnlock);
 BENCHMARK(STD_S_SLockSUnlock);
 
-BENCHMARK(PM_pipeline_benchmark);
-BENCHMARK(STD_pipeline_benchmark);
+BENCHMARK(PM_pipeline_benchmark_long)->UseRealTime();
+BENCHMARK(STD_pipeline_benchmark_long)->UseRealTime();
+
+BENCHMARK(PM_pipeline_benchmark_gaming)->UseRealTime();
+BENCHMARK(STD_pipeline_benchmark_gaming)->UseRealTime();
+
+BENCHMARK(PM_pipeline_benchmark_audio)->UseRealTime();
+BENCHMARK(STD_pipeline_benchmark_audio)->UseRealTime();
+
+BENCHMARK(PM_pipeline_benchmark_fast)->UseRealTime();
+BENCHMARK(STD_pipeline_benchmark_fast)->UseRealTime();
 
 BENCHMARK_MAIN();

--- a/include/priority_mutex.h
+++ b/include/priority_mutex.h
@@ -67,9 +67,6 @@ namespace PrioSync{// the name has yet to be chosen
          */
         void lock(Priority_t priority = 0){
 
-            if (priority >= N)// this check may be wasteful at runtime I might keep this as UB
-                throw std::system_error(std::make_error_code(std::errc::invalid_argument));
-
             std::unique_lock<std::mutex> lock(_internalMtx);
             auto& myPriority = _priorities[priority];
 
@@ -96,7 +93,6 @@ namespace PrioSync{// the name has yet to be chosen
 
             {
             std::lock_guard<std::mutex> lock(_internalMtx);
-            if (!_lock_is_owned_by_me())return;// this check may be wasteful yes we define a behavior that otherwise would be undefined by at the cost of 1 check which also call a std::thread::id constructor
             _owner = std::thread::id();
             p = _find_first_priority();
             }
@@ -118,9 +114,6 @@ namespace PrioSync{// the name has yet to be chosen
          * @return bool 
          */
         [[nodiscard]] bool try_lock(Priority_t priority = 0){
-
-            if (priority >= N)// this check may be wasteful at runtime I might keep this as UB
-                throw std::system_error(std::make_error_code(std::errc::invalid_argument));
 
             std::lock_guard<std::mutex> lock(_internalMtx);
             auto max_p = _find_first_priority(priority);

--- a/include/shared_priority_mutex.h
+++ b/include/shared_priority_mutex.h
@@ -69,9 +69,6 @@ namespace PrioSync{// the name has yet to be chosen
          */
         void lock(Priority_t priority = 0){
 
-            if (priority >= N)// this check may be wasteful at runtime I might keep this as UB
-                throw std::system_error(std::make_error_code(std::errc::invalid_argument));
-
             std::unique_lock<std::mutex> lock(_internalMtx);
             auto& myPriority = _priorities[priority];
 
@@ -102,7 +99,6 @@ namespace PrioSync{// the name has yet to be chosen
 
             {
             std::lock_guard<std::mutex> lock(_internalMtx);
-            if (!_lock_is_owned_by_me())return;// this check may be wasteful yes we define a behavior that otherwise would be undefined by at the cost of 1 check which also call a std::thread::id constructor
             _owner = std::thread::id();
             p = _find_first_priority();
             }
@@ -133,9 +129,6 @@ namespace PrioSync{// the name has yet to be chosen
          */
         [[nodiscard]] bool try_lock(Priority_t priority = 0){
 
-            if (priority >= N)// this check may be wasteful at runtime I might keep this as UB
-                throw std::system_error(std::make_error_code(std::errc::invalid_argument));
-
             std::lock_guard<std::mutex> lock(_internalMtx);
             if (_lock_is_owned() || _totalCurrentReaders > 0 || _find_first_priority(priority) < priority)
                 return false;
@@ -154,9 +147,6 @@ namespace PrioSync{// the name has yet to be chosen
          * \endcode
          */
         void lock_shared(Priority_t priority = 0){
-
-            if (priority >= N)// this check may be wasteful at runtime I might keep this as UB
-                throw std::system_error(std::make_error_code(std::errc::invalid_argument));
 
             std::unique_lock<std::mutex> lock(_internalMtx);
             auto& myPriority = _priorities[priority];
@@ -186,9 +176,6 @@ namespace PrioSync{// the name has yet to be chosen
          */
         [[nodiscard]] bool try_lock_shared(Priority_t priority = 0){
 
-            if (priority >= N)// this check may be wasteful at runtime I might keep this as UB
-                throw std::system_error(std::make_error_code(std::errc::invalid_argument));
-
             std::lock_guard<std::mutex> lock(_internalMtx);
             if (_lock_is_owned() ||
                 _totalCurrentReaders == _max_threads ||
@@ -212,8 +199,6 @@ namespace PrioSync{// the name has yet to be chosen
 
             {
             std::lock_guard<std::mutex> lock(_internalMtx);
-            // here I need to find a way to say "you have previously taken the lock_shared" or we could leave this behavior
-            // semaphore like if I can`t figure out a decent, not costly, way of imposing this condition.
             _totalCurrentReaders--;
             p = _find_first_priority();
             }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -26,9 +26,9 @@ TEST(PriorityMutex_ControlledScheduling, TryLockTest) {
     EXPECT_EQ(PMscenario3::ret, PMscenario3::expected);
 }
 
-TEST(PriorityMutex_ControlledScheduling, MutexOrSemaphore) {
-    EXPECT_EQ(PMscenario4::ret, PMscenario4::expected);
-}
+//TEST(PriorityMutex_ControlledScheduling, MutexOrSemaphore) {
+//    EXPECT_EQ(PMscenario4::ret, PMscenario4::expected);
+//}
 
 TEST(SharedPriorityMutex_ControlledScheduling, LockUnlockTest) {
     EXPECT_EQ(SPMscenario1::expected, SPMscenario1::ret);
@@ -46,9 +46,9 @@ TEST(SharedPriorityMutex_ControlledScheduling, LockSharedTest) {
     EXPECT_EQ(SPMscenario4::ret, SPMscenario4::expected);
 }
 
-TEST(SharedPriorityMutex_ControlledScheduling, MutexOrSemaphore) {
-    EXPECT_EQ(SPMscenario5::ret, SPMscenario5::expected);
-}
+//TEST(SharedPriorityMutex_ControlledScheduling, MutexOrSemaphore) {
+//    EXPECT_EQ(SPMscenario5::ret, SPMscenario5::expected);
+//}
 
 TEST(SharedPriorityMutex_ControlledScheduling, PriorityBehavior) {
     EXPECT_EQ(SPMscenario6::ret, SPMscenario6::expected);


### PR DESCRIPTION
Add benchmarks (_fast is too imprecise due to the BS::thread_pool dynamic allocations wasting too much time). Remove SemaphoreOrMutex test since now I undefined the behavior that was making that test pass.